### PR TITLE
Make `git` a feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       image: ${{ github.actor }}/${{ needs.repository.outputs.repository }}-${{ matrix.os }}-minimal
       file: Dockerfile.${{ matrix.os }}
       build-args: |
-        INSTALL_FEATURES=sudo codecli
+        INSTALL_FEATURES=sudo codecli git
       username: ${{ github.actor }}
     secrets:
       password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -47,9 +47,9 @@ jobs:
         os: [alpine]
     with:
       image: ${{ github.actor }}/${{ needs.repository.outputs.repository }}-${{ matrix.os }}-minimal
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       build-args: |
-        INSTALL_FEATURES=sudo codecli
+        INSTALL_FEATURES=sudo codecli git
       username: ${{ github.actor }}
     secrets:
       password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -47,7 +47,7 @@ jobs:
         os: [alpine]
     with:
       image: ${{ github.actor }}/${{ needs.repository.outputs.repository }}-${{ matrix.os }}-minimal
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
       build-args: |
         INSTALL_FEATURES=sudo codecli git
       username: ${{ github.actor }}

--- a/install.sh
+++ b/install.sh
@@ -117,6 +117,7 @@ zip
 jq
 bash
 less
+make
 - gcompat
 EOF
 

--- a/install.sh
+++ b/install.sh
@@ -115,8 +115,6 @@ install_ondemand<<EOF
 curl
 zip
 jq
-git
-git-lfs
 bash
 less
 - gcompat

--- a/share/features/20-install-git.sh
+++ b/share/features/20-install-git.sh
@@ -44,4 +44,4 @@ git-annex
 EOF
 
 as_root internet_install "$INSTALL_GIT_LEFTHOOK_URL" lefthook "$INSTALL_GIT_LEFTHOOK_SHA512"
-as_root PREFIX="$INSTALL_PREFIX" internet_install "$INSTALL_GIT_EXTRAS_URL" git-extras "$INSTALL_GIT_EXTRAS_SHA512"
+PREFIX="$INSTALL_PREFIX" as_root internet_install "$INSTALL_GIT_EXTRAS_URL" git-extras "$INSTALL_GIT_EXTRAS_SHA512"

--- a/share/features/20-install-git.sh
+++ b/share/features/20-install-git.sh
@@ -41,6 +41,7 @@ lazygit
 tig
 gitui
 git-annex
+- util-linux-misc
 EOF
 
 as_root internet_install "$INSTALL_GIT_LEFTHOOK_URL" lefthook "$INSTALL_GIT_LEFTHOOK_SHA512"

--- a/share/features/20-install-git.sh
+++ b/share/features/20-install-git.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Shell sanity. Stop on errors and undefined variables.
+set -eu
+
+# Absolute location of the script where this script is located.
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+
+# Hurry up and find the libraries
+for lib in common system; do
+  for d in ../../lib ../lib lib; do
+    if [ -d "${INSTALL_ROOTDIR}/$d" ]; then
+      # shellcheck disable=SC1090
+      . "${INSTALL_ROOTDIR}/$d/${lib}.sh"
+      break
+    fi
+  done
+done
+
+
+# All following vars have defaults here, but will be set and inherited from
+# calling install.sh script in the normal case.
+: "${INSTALL_VERBOSE:=0}"
+: "${INSTALL_LOG:=2}"
+: "${INSTALL_USER:="coder"}"
+
+: "${INSTALL_GIT_LEFTHOOK_URL:="https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.alpine.sh"}"
+: "${INSTALL_GIT_LEFTHOOK_SHA512:="6c2b28a84501c4761a7a49dc4e4b71b580d8bf644675baa057928ff567bc611bdada62f7d2cbf2cd0150af62d2e94d2db0f3767ad9beadeb6ddf0e3a527313c4"}"
+
+log_init INSTALL
+
+
+install_ondemand<<EOF
+git
+git-lfs
+pre-commit
+lazygit
+tig
+gitui
+git-annex
+EOF
+
+as_root internet_install "$INSTALL_GIT_LEFTHOOK_URL" dotnet "$INSTALL_GIT_LEFTHOOK_SHA512"

--- a/share/features/20-install-git.sh
+++ b/share/features/20-install-git.sh
@@ -22,10 +22,13 @@ done
 # calling install.sh script in the normal case.
 : "${INSTALL_VERBOSE:=0}"
 : "${INSTALL_LOG:=2}"
-: "${INSTALL_USER:="coder"}"
+: "${INSTALL_PREFIX:="/usr/local"}"
 
 : "${INSTALL_GIT_LEFTHOOK_URL:="https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.alpine.sh"}"
 : "${INSTALL_GIT_LEFTHOOK_SHA512:="6c2b28a84501c4761a7a49dc4e4b71b580d8bf644675baa057928ff567bc611bdada62f7d2cbf2cd0150af62d2e94d2db0f3767ad9beadeb6ddf0e3a527313c4"}"
+
+: "${INSTALL_GIT_EXTRAS_URL:="https://raw.githubusercontent.com/tj/git-extras/main/install.sh"}"
+: "${INSTALL_GIT_EXTRAS_SHA512:="915def79bb2f86448d5fad8542ceb3265cf4a99d95f2da4c6d9d07f1c16d1c26928f1579fa916ad20efe05f6cf55dbcc1c027cd753f1091f0aeb7e084ddf1c71"}"
 
 log_init INSTALL
 
@@ -40,4 +43,5 @@ gitui
 git-annex
 EOF
 
-as_root internet_install "$INSTALL_GIT_LEFTHOOK_URL" dotnet "$INSTALL_GIT_LEFTHOOK_SHA512"
+as_root internet_install "$INSTALL_GIT_LEFTHOOK_URL" lefthook "$INSTALL_GIT_LEFTHOOK_SHA512"
+as_root PREFIX="$INSTALL_PREFIX" internet_install "$INSTALL_GIT_EXTRAS_URL" git-extras "$INSTALL_GIT_EXTRAS_SHA512"


### PR DESCRIPTION
Make `git` a feature and arrange for it to be present in both images. Add a number of `git` "essentials": a few TUIs, hooks managers, support for large files, etc.

Close #16 