### PR TITLE
Add option to select logs, default to code

### DIFF
--- a/etc/init.d/20-sshd.sh
+++ b/etc/init.d/20-sshd.sh
@@ -188,4 +188,4 @@ configure_sshd
 touch "$SSHD_LOGFILE"
 as_root /usr/sbin/sshd -D -f "${SSHD_CONFIG_DIR}/sshd_config" -E "$SSHD_LOGFILE" &
 pid_sshd=$!
-verbose "sshd started with pid %s" "$pid_sshd"
+verbose "sshd started with pid %s. Logs at %s" "$pid_sshd" "$SSHD_LOGFILE"

--- a/share/tunnels/codecli.sh
+++ b/share/tunnels/codecli.sh
@@ -30,6 +30,7 @@ done
 : "${TUNNEL_PREFIX:="/usr/local"}"
 : "${TUNNEL_USER_PREFIX:="${HOME}/.local"}"
 : "${TUNNEL_ALIAS:=}"
+: "${TUNNEL_REEXPOSE:=""}"
 
 
 # shellcheck disable=SC2034 # Used for logging/usage
@@ -104,6 +105,11 @@ fi
 CODE_BIN=$(find_inpath code "$TUNNEL_USER_PREFIX" "$TUNNEL_PREFIX")
 if [ -n "$CODE_BIN" ]; then
   tunnel_configure
-  tunnel_login "$CODE_BIN" | "$TUNNEL_ROOTDIR/../orchestration/logger.sh" -s "$CODE_BIN"
-  tunnel_start "$CODE_BIN" | "$TUNNEL_ROOTDIR/../orchestration/logger.sh" -s "$CODE_BIN"
+  if [ -z "$TUNNEL_REEXPOSE" ] || printf %s\\n "$TUNNEL_REEXPOSE" | grep -qF 'code'; then
+    tunnel_login "$CODE_BIN" | "$TUNNEL_ROOTDIR/../orchestration/logger.sh" -s "$CODE_BIN"
+    tunnel_start "$CODE_BIN" | "$TUNNEL_ROOTDIR/../orchestration/logger.sh" -s "$CODE_BIN"
+  else
+    tunnel_login "$CODE_BIN"
+    tunnel_start "$CODE_BIN"
+  fi
 fi

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -63,10 +63,14 @@ done
 # List of tunnels to establish. When empty, all tunnels will be started.
 : "${TUNNEL_TUNNELS:=""}"
 
+# List of services which logs we should re-expose to the main container log.
+# When empty, all services will be re-exposed.
+: "${TUNNEL_REEXPOSE:="code"}"
+
 
 # shellcheck disable=SC2034 # Used for logging/usage
 CODER_DESCR="tunnel starter"
-while getopts "a:fg:k:l:n:p:s:S:T:vh" opt; do
+while getopts "a:fg:k:l:L:n:p:s:S:T:vh" opt; do
   case "$opt" in
     a) # Alias for the home user
       TUNNEL_ALIAS="$OPTARG";;
@@ -78,6 +82,8 @@ while getopts "a:fg:k:l:n:p:s:S:T:vh" opt; do
       TUNNEL_HOOK="$OPTARG";;
     l) # Where to send logs
       TUNNEL_LOG="$OPTARG";;
+    L) # List of services to re-expose in log
+      TUNNEL_REEXPOSE="$OPTARG";;
     n) # Name of the tunnel, empty for random name
       TUNNEL_NAME="$OPTARG";;
     p) # Tunnel provider
@@ -176,7 +182,6 @@ fi
 start_deps "tunnel" "$TUNNEL_TUNNELS_DIR" "$TUNNEL_TUNNELS" "*.sh" 1 >/dev/null
 
 # TODO: Rotate the logs from tunnels and services at regular intervals
-# TODO: Make re-expose of logs a configurable option?
 
 while true; do
   sleep 1


### PR DESCRIPTION
Add an option to select the logs of which underlying services should be forwarded. Add support for forwarding of logs of dockerd. The default is to only forward the logs of the code tunnel cli (since it prints out the URL for the tunnel and the URL for authorizing the device).

Close #23 