### PR TITLE
Log rotation

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,6 +26,7 @@ RUN chmod a+x ${INSTALL_PREFIX}/bin/*.sh && \
 
 # Copy the init scripts and other files.
 COPY *.sh ${INSTALL_PREFIX}/bin/
+COPY etc/*.env ${INSTALL_PREFIX}/etc/
 COPY etc/init.d/*.sh ${INSTALL_PREFIX}/etc/init.d/
 COPY share/tunnels/*.sh ${INSTALL_PREFIX}/share/tunnels/
 COPY share/orchestration/*.sh ${INSTALL_PREFIX}/share/orchestration/

--- a/build/hotfix.sh
+++ b/build/hotfix.sh
@@ -2,7 +2,7 @@
 
 # This script is used to apply hotfixes.
 
-set -eu
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 HOTFIX_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/build/hotfix.sh
+++ b/build/hotfix.sh
@@ -5,7 +5,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-HOTFIX_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+HOTFIX_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/build/install.sh
+++ b/build/install.sh
@@ -108,6 +108,7 @@ openssh
 bash
 less
 make
+logrotate
 inotifywait inotify-tools
 - gcompat
 EOF

--- a/build/install.sh
+++ b/build/install.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/etc/cron.env
+++ b/etc/cron.env
@@ -1,0 +1,17 @@
+# Check for date match every minute (so we can have a forgivable regex for the
+# seconds part). The date format is YYYY-MM-DD HH:MM:SS, by default.
+CRON_INTERVAL=60
+
+# Run every day at 04:20:xx (seconds are not important, but ensured only one run
+# per minute through the interval)
+CRON_WHEN="[0-9]{4}-[0-9]{2}-[0-9]{2} 04:20:[0-9]{2}"
+
+# Location of the logrotate script. Use the CRON_ROOTDIR variable to
+# determine the location of the script.
+CRON_BIN=${CRON_ROOTDIR}/../../share/orchestration/logrotate.sh
+
+# Run as a "daemon" in the background
+CRON_DAEMONIZE=1
+
+# Force logging to a common services log file
+CRON_LOG=${CRON_ROOTDIR}/../../log/services.log

--- a/etc/init.d/01-system.sh
+++ b/etc/init.d/01-system.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 SYSTEM_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/etc/init.d/01-system.sh
+++ b/etc/init.d/01-system.sh
@@ -17,6 +17,10 @@ for lib in common system; do
   done
 done
 
+# Arrange to set the CODER_BIN variable to the name of the script
+bin_name
+
+
 
 # Level of verbosity, the higher the more verbose. All messages are sent to the
 # file at SYSTEM_LOG.
@@ -27,6 +31,9 @@ done
 
 # inotify settings (maximum for vscode)
 : "${SYSTEM_INOTIFY_MAX:=524288}"
+
+# Environment file to load for reading defaults from.
+: "${SYSTEM_DEFAULTS:="${SYSTEM_ROOTDIR}/../${CODER_BIN}.env"}"
 
 
 # shellcheck disable=SC2034 # Used from functions in common.sh
@@ -47,6 +54,9 @@ while getopts "l:vh" opt; do
 done
 
 log_init SYSTEM
+
+# Load defaults
+[ -n "$SYSTEM_DEFAULTS" ] && read_envfile "$SYSTEM_DEFAULTS" SYSTEM
 
 current=$(cat /proc/sys/fs/inotify/max_user_watches 2>/dev/null || true)
 if [ "$current" != "$SYSTEM_INOTIFY_MAX" ]; then

--- a/etc/init.d/01-system.sh
+++ b/etc/init.d/01-system.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-SYSTEM_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+SYSTEM_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/etc/init.d/10-dockerd.sh
+++ b/etc/init.d/10-dockerd.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-DOCKERD_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+DOCKERD_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 for lib in common system docker; do
   for d in ../../lib ../lib lib; do
     if [ -d "${DOCKERD_ROOTDIR}/$d" ]; then

--- a/etc/init.d/10-dockerd.sh
+++ b/etc/init.d/10-dockerd.sh
@@ -15,6 +15,9 @@ for lib in common system docker; do
   done
 done
 
+# Arrange to set the CODER_BIN variable to the name of the script
+bin_name
+
 
 # Level of verbosity, the higher the more verbose. All messages are sent to the
 # file at DOCKERD_LOG.
@@ -27,6 +30,9 @@ done
 
 # Where the docker daemon listens, defaults to the standard docker socket.
 : "${DOCKERD_SOCK:="/var/run/docker.sock"}"
+
+# Environment file to load for reading defaults from.
+: "${DOCKERD_DEFAULTS:="${DOCKERD_ROOTDIR}/../${CODER_BIN}.env"}"
 
 # Detach in the background
 : "${DOCKERD_DAEMONIZE:=0}"
@@ -53,6 +59,10 @@ while getopts "l:vh" opt; do
 done
 
 log_init DOCKERD
+
+# Load defaults
+[ -n "$DOCKERD_DEFAULTS" ] && read_envfile "$DOCKERD_DEFAULTS" DOCKERD
+
 
 dockerd_start() {
   as_root dockerd 2>&1 | tee -a "$DOCKERD_LOGFILE" > /dev/null &

--- a/etc/init.d/10-dockerd.sh
+++ b/etc/init.d/10-dockerd.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 DOCKERD_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/etc/init.d/20-sshd.sh
+++ b/etc/init.d/20-sshd.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 SSHD_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/etc/init.d/20-sshd.sh
+++ b/etc/init.d/20-sshd.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-SSHD_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+SSHD_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/etc/init.d/20-sshd.sh
+++ b/etc/init.d/20-sshd.sh
@@ -17,6 +17,9 @@ for lib in common system; do
   done
 done
 
+# Arrange to set the CODER_BIN variable to the name of the script
+bin_name
+
 
 # Level of verbosity, the higher the more verbose. All messages are sent to the
 # file at SSHD_LOG.
@@ -48,6 +51,9 @@ done
 # Log level to use in sshd. One of: QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG,
 # DEBUG1, DEBUG2, and DEBUG3
 : "${SSHD_LOGLEVEL:="INFO"}"
+
+# Environment file to load for reading defaults from.
+: "${SSHD_DEFAULTS:="${SSHD_ROOTDIR}/../${CODER_BIN}.env"}"
 
 # Detach in the background
 : "${SSHD_DAEMONIZE:=0}"
@@ -85,6 +91,8 @@ shift $((OPTIND - 1))
 
 log_init SSHD
 
+# Load defaults
+[ -n "$SSHD_DEFAULTS" ] && read_envfile "$SSHD_DEFAULTS" SSHD
 
 make_owned_dir() {
   as_root mkdir -p "$1"

--- a/etc/init.d/30-forges.sh
+++ b/etc/init.d/30-forges.sh
@@ -17,6 +17,9 @@ for lib in common system; do
   done
 done
 
+# Arrange to set the CODER_BIN variable to the name of the script
+bin_name
+
 
 # Level of verbosity, the higher the more verbose. All messages are sent to the
 # file at FORGES_LOG.
@@ -32,7 +35,14 @@ done
 # GitHub user to fetch keys from
 : "${FORGES_GITHUB_USER:="${TUNNEL_GITHUB_USER:-""}"}"
 
+# Environment file to load for reading defaults from.
+: "${FORGES_DEFAULTS:="${FORGES_ROOTDIR}/../${CODER_BIN}.env"}"
+
+
 log_init FORGES
+
+# Load defaults
+[ -n "$FORGES_DEFAULTS" ] && read_envfile "$FORGES_DEFAULTS" FORGES
 
 
 ensure_ownership() {

--- a/etc/init.d/30-forges.sh
+++ b/etc/init.d/30-forges.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 FORGES_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/etc/init.d/30-forges.sh
+++ b/etc/init.d/30-forges.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-FORGES_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+FORGES_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/etc/init.d/40-cron.sh
+++ b/etc/init.d/40-cron.sh
@@ -28,7 +28,11 @@ bin_name
 # Where to send logs
 : "${CRON_LOG:="${TUNNEL_LOG:-"2"}"}"
 
+# Prefix where things are installed.
 : "${CRON_PREFIX:="${TUNNEL_PREFIX:-"/usr/local"}"}"
+
+# How often should we check for action
+: "${CRON_INTERVAL:=60}"
 
 # Format of the date to use when checking for action
 : "${CRON_DATE_FORMAT:=%Y-%m-%d %H:%M:%S}"
@@ -82,6 +86,7 @@ if [ -z "$CRON_BIN" ] && [ $# -eq 0 ]; then
   error "No command to run"
   usage 1
 fi
+check_int "$CRON_INTERVAL"
 
 # If we are to daemonize, do it now and exit. Export all our variables to the
 # daemon so it starts the same way this script was started.

--- a/etc/init.d/40-cron.sh
+++ b/etc/init.d/40-cron.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 CRON_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/etc/init.d/40-cron.sh
+++ b/etc/init.d/40-cron.sh
@@ -109,12 +109,10 @@ while true; do
       else
         warn "Command failed"
       fi
+    elif "$CRON_BIN" "$@"; then
+      debug "Command ran successfully"
     else
-      if "$CRON_BIN" "$@"; then
-        debug "Command ran successfully"
-      else
-        warn "Command failed"
-      fi
+      warn "Command failed"
     fi
   else
     trace "$now does not match $CRON_WHEN"

--- a/etc/init.d/40-cron.sh
+++ b/etc/init.d/40-cron.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-CRON_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+CRON_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do
@@ -67,7 +67,7 @@ while getopts "b:w:vh-" opt; do
       CRON_VERBOSE=$((CRON_VERBOSE + 1));;
     h) # Show help
       usage 0 CRON;;
-    -) # End of options, everything else passed to sshd blindly
+    -) # End of options, everything else passed to binary blindly, or forms command to run.
       break;;
     *)  # Unknown option
       usage 1

--- a/etc/init.d/40-cron.sh
+++ b/etc/init.d/40-cron.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+
+# Shell sanity. Stop on errors and undefined variables.
+set -eu
+
+# Absolute location of the script where this script is located.
+CRON_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+
+# Hurry up and find the libraries
+for lib in common system; do
+  for d in ../../lib ../lib lib; do
+    if [ -d "${CRON_ROOTDIR}/$d" ]; then
+      # shellcheck disable=SC1090
+      . "${CRON_ROOTDIR}/$d/${lib}.sh"
+      break
+    fi
+  done
+done
+
+# Arrange to set the CODER_BIN variable to the name of the script
+bin_name
+
+
+# Level of verbosity, the higher the more verbose. All messages are sent to the
+# file at CRON_LOG.
+: "${CRON_VERBOSE:="${TUNNEL_VERBOSE:-"0"}"}"
+
+# Where to send logs
+: "${CRON_LOG:="${TUNNEL_LOG:-"2"}"}"
+
+: "${CRON_PREFIX:="${TUNNEL_PREFIX:-"/usr/local"}"}"
+
+# Format of the date to use when checking for action
+: "${CRON_DATE_FORMAT:=%Y-%m-%d %H:%M:%S}"
+
+# Regular expression to match the date format to decide when to run. Empty
+# (default) for never.
+: "${CRON_WHEN:=""}"
+
+# Environment file to load for reading defaults from.
+: "${CRON_DEFAULTS:="${CRON_ROOTDIR}/../${CODER_BIN}.env"}"
+
+# Binary to run, will be prepended to the arguments given to this script. Empty
+# by default.
+: "${CRON_BIN:=""}"
+
+# Detach in the background
+: "${CRON_DAEMONIZE:=0}"
+
+# Prevent detaching in the background (RESERVED for use by ourselves)
+: "${_CRON_PREVENT_DAEMONIZATION:=0}"
+
+
+# shellcheck disable=SC2034 # Used from functions in common.sh
+CODE_DESCR="Simplistic cron daemon startup"
+while getopts "b:w:vh-" opt; do
+  case "$opt" in
+    b) # Binary to run, will be prepended to the arguments given to this script.
+      CRON_BIN="$OPTARG";;
+    w) # When to run the cron job. Empty (default) for never.
+      CRON_WHEN="$OPTARG";;
+    v) # Increase verbosity, repeat to increase
+      CRON_VERBOSE=$((CRON_VERBOSE + 1));;
+    h) # Show help
+      usage 0 CRON;;
+    -) # End of options, everything else passed to sshd blindly
+      break;;
+    *)  # Unknown option
+      usage 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+log_init CRON
+
+# Load defaults
+[ -n "$CRON_DEFAULTS" ] && read_envfile "$CRON_DEFAULTS" CRON
+
+# When no command is provided, bail out
+if [ -z "$CRON_BIN" ] && [ $# -eq 0 ]; then
+  error "No command to run"
+  usage 1
+fi
+
+# If we are to daemonize, do it now and exit. Export all our variables to the
+# daemon so it starts the same way this script was started.
+if ! is_true "$_CRON_PREVENT_DAEMONIZATION" && is_true "$CRON_DAEMONIZE"; then
+  # Do not daemonize the daemon!
+  _CRON_PREVENT_DAEMONIZATION=1
+  CRON_DAEMONIZE=0
+  daemonize CRON "$@"
+fi
+
+
+verbose "Will run when date matches $CRON_WHEN (interval: ${CRON_INTERVAL}s, PID: $$): $CRON_BIN $*"
+while true; do
+  now=$(date +"$CRON_DATE_FORMAT")
+  if [ -n "$CRON_WHEN" ] && printf %s\\n "$now" | grep -qE "$CRON_WHEN"; then
+    verbose "Running at $now"
+    if [ -z "$CRON_BIN" ]; then
+      if "$@"; then
+        debug "Command ran successfully"
+      else
+        warn "Command failed"
+      fi
+    else
+      if "$CRON_BIN" "$@"; then
+        debug "Command ran successfully"
+      else
+        warn "Command failed"
+      fi
+    fi
+  else
+    trace "$now does not match $CRON_WHEN"
+  fi
+  sleep "$CRON_INTERVAL"
+done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -160,6 +160,7 @@ daemonize() {
   shift
 
   export_varset "$_namespace"
+  export_varset "_$_namespace"
 
   # Restart ourselves in the background, with same arguments.
   (

--- a/share/features/01-install-sudo.sh
+++ b/share/features/01-install-sudo.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/features/01-install-sudo.sh
+++ b/share/features/01-install-sudo.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/02-install-docker.sh
+++ b/share/features/02-install-docker.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/features/02-install-docker.sh
+++ b/share/features/02-install-docker.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/10-install-codecli.sh
+++ b/share/features/10-install-codecli.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common install system; do

--- a/share/features/10-install-codecli.sh
+++ b/share/features/10-install-codecli.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/11-install-cloudflare.sh
+++ b/share/features/11-install-cloudflare.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common install system; do

--- a/share/features/11-install-cloudflare.sh
+++ b/share/features/11-install-cloudflare.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/20-install-git.sh
+++ b/share/features/20-install-git.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common install system; do

--- a/share/features/20-install-git.sh
+++ b/share/features/20-install-git.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/30-install-node.sh
+++ b/share/features/30-install-node.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common install system; do

--- a/share/features/30-install-node.sh
+++ b/share/features/30-install-node.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/31-install-dotnet.sh
+++ b/share/features/31-install-dotnet.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common install system; do

--- a/share/features/31-install-dotnet.sh
+++ b/share/features/31-install-dotnet.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/32-install-powershell.sh
+++ b/share/features/32-install-powershell.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common install system; do

--- a/share/features/32-install-powershell.sh
+++ b/share/features/32-install-powershell.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/features/60-install-aws.sh
+++ b/share/features/60-install-aws.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/features/60-install-aws.sh
+++ b/share/features/60-install-aws.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 INSTALL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/orchestration/gist.sh
+++ b/share/orchestration/gist.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 GIST_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/orchestration/gist.sh
+++ b/share/orchestration/gist.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-GIST_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+GIST_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/orchestration/logger.sh
+++ b/share/orchestration/logger.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-LOGGER_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+LOGGER_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/orchestration/logger.sh
+++ b/share/orchestration/logger.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 LOGGER_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/orchestration/logrotate.sh
+++ b/share/orchestration/logrotate.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-LOGROTATE_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+LOGROTATE_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/orchestration/logrotate.sh
+++ b/share/orchestration/logrotate.sh
@@ -103,4 +103,4 @@ find "$LOGROTATE_LOGDIR" -type f -name "*.log" | while IFS="$newline" read -r fi
 done
 
 # Now we have a configuration file, we can run logrotate on it.
-"$LWRAP" logrotate -s "$LOGROTATE_STATUS" "$config" || true
+"$LWRAP" logrotate -s "$LOGROTATE_STATUS" "$config"

--- a/share/orchestration/logrotate.sh
+++ b/share/orchestration/logrotate.sh
@@ -19,12 +19,18 @@ done
 
 : "${XDG_STATE_HOME:="${HOME}/.local/state"}"
 
-# All following vars have defaults here, but will be set and inherited from
+# All following vars have defaults here, but most will be set and inherited from
 # the calling tunnel.sh script.
 : "${LOGROTATE_VERBOSE:="${TUNNEL_VERBOSE:-"0"}"}"
 : "${LOGROTATE_LOG:="${TUNNEL_LOG:-"2"}"}"
 : "${LOGROTATE_PREFIX:="${TUNNEL_PREFIX:-"/usr/local"}"}"
+
+# Location of the log files that will be rotated.
 : "${LOGROTATE_LOGDIR:="${LOGROTATE_PREFIX}/log"}"
+
+# Location of the logrotate status file. This is used to keep track of the last
+# time the log files were rotated. It needs to be in a location that is
+# accessible by the user, since logrotate is run as the user.
 : "${LOGROTATE_STATUS:="${XDG_STATE_HOME}/logrotate.status"}"
 
 # shellcheck disable=SC2034 # Used for logging/usage

--- a/share/orchestration/logrotate.sh
+++ b/share/orchestration/logrotate.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+# Shell sanity. Stop on errors and undefined variables.
+set -eu
+
+# Absolute location of the script where this script is located.
+LOGROTATE_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+
+# Hurry up and find the libraries
+for lib in common system; do
+  for d in ../../lib ../lib lib; do
+    if [ -d "${LOGROTATE_ROOTDIR}/$d" ]; then
+      # shellcheck disable=SC1090
+      . "${LOGROTATE_ROOTDIR}/$d/${lib}.sh"
+      break
+    fi
+  done
+done
+
+: "${XDG_STATE_HOME:="${HOME}/.local/state"}"
+
+# All following vars have defaults here, but will be set and inherited from
+# the calling tunnel.sh script.
+: "${LOGROTATE_VERBOSE:="${TUNNEL_VERBOSE:-"0"}"}"
+: "${LOGROTATE_LOG:="${TUNNEL_LOG:-"2"}"}"
+: "${LOGROTATE_PREFIX:="${TUNNEL_PREFIX:-"/usr/local"}"}"
+: "${LOGROTATE_LOGDIR:="${LOGROTATE_PREFIX}/log"}"
+: "${LOGROTATE_STATUS:="${XDG_STATE_HOME}/logrotate.status"}"
+
+# shellcheck disable=SC2034 # Used for logging/usage
+CODER_DESCR="logrotate updater"
+while getopts "L:s:vh-" opt; do
+  case "$opt" in
+    L) # Log directory
+      LOGROTATE_LOGDIR="$OPTARG";;
+    s) # Status file
+      LOGROTATE_STATUS="$OPTARG";;
+    v) # Increase verbosity, repeat to increase
+      LOGROTATE_VERBOSE=$((LOGROTATE_VERBOSE + 1));;
+    h) # Show help
+      usage 0 LOGROTATE
+      ;;
+    -) # End of options, file name to follow
+      break;;
+    *)  # Unknown option
+      usage 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+
+log_init LOGROTATE
+
+check_command logrotate || error "logrotate not found, please install it"
+mkdir -p "$(dirname "$LOGROTATE_STATUS")" || error "Cannot create directory for logrotate status file %s" "$LOGROTATE_STATUS"
+
+LWRAP="$LOGROTATE_ROOTDIR/lwrap.sh"
+
+# Create a temporary file for the logrotate configuration, arrange to remove it
+# when we are done.
+config=$(mktemp -t logrotate.XXXXXX)
+trap 'rm -f "$config"; trap - EXIT; exit' EXIT INT HUP TERM
+
+# Add a header to the logrotate configuration file
+cat <<'EOF' > "$config"
+# Online documentation for logrotate: https://linux.die.net/man/8/logrotate
+
+# Keep 3 weeks of logs, compress them.
+rotate 3
+weekly
+compress
+
+# Handle errors gracefully
+missingok
+notifempty
+
+# To respect ownership and permissions, the main file will be truncated (as it
+# is not written to by the root user).
+copytruncate
+
+# All our files end with .log, this will arrange for .1, .2, etc to be at a
+# better location in the filenames of the rotated files.
+extension .log
+
+# Rotate the log files of the services/wrapper processes
+EOF
+
+# Find all the log files in the log directory and add them to the logrotate
+# configuration file. We use a newline as the IFS separator to allow for
+# spaces in the filenames.
+newline=$(printf \\n)
+find "$LOGROTATE_LOGDIR" -type f -name "*.log" | while IFS="$newline" read -r file; do
+  if [ -f "$file" ]; then
+    printf "%s {}\n" "$file" >> "$config"
+  fi
+done
+
+# Now we have a configuration file, we can run logrotate on it.
+"$LWRAP" logrotate -s "$LOGROTATE_STATUS" "$config" || true

--- a/share/orchestration/logrotate.sh
+++ b/share/orchestration/logrotate.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 LOGROTATE_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/orchestration/lwrap.sh
+++ b/share/orchestration/lwrap.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 LWRAP_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/orchestration/lwrap.sh
+++ b/share/orchestration/lwrap.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-LWRAP_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+LWRAP_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common; do

--- a/share/orchestration/notify.sh
+++ b/share/orchestration/notify.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-NOTIFY_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+NOTIFY_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/orchestration/notify.sh
+++ b/share/orchestration/notify.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 NOTIFY_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/tunnels/cloudflare.sh
+++ b/share/tunnels/cloudflare.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/tunnels/cloudflare.sh
+++ b/share/tunnels/cloudflare.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/share/tunnels/codecli.sh
+++ b/share/tunnels/codecli.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system; do

--- a/share/tunnels/codecli.sh
+++ b/share/tunnels/codecli.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -246,8 +246,6 @@ if [ -n "${TUNNEL_GIST_FILE:-}" ]; then
       "${TUNNEL_ORCHESTRATION_DIR}/gist.sh" -- "$TUNNEL_GIST_FILE" &
 fi
 
-# TODO: Rotate the logs from tunnels and services at regular intervals
-
 while true; do
   sleep 5
 done

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Shell sanity. Stop on errors and undefined variables.
-set -eu
+# Shell sanity. Stop on errors, undefined variables and pipeline errors.
+# shellcheck disable=SC3040 # ok, see: https://unix.stackexchange.com/a/654932
+set -euo pipefail
 
 # Absolute location of the script where this script is located.
 TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -4,7 +4,7 @@
 set -eu
 
 # Absolute location of the script where this script is located.
-TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(readlink -f "$0")")")" && pwd -P )
+TUNNEL_ROOTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$(realpath "$0")")")" && pwd -P )
 
 # Hurry up and find the libraries
 for lib in common system install; do


### PR DESCRIPTION
Create a cron service, use it to trigger a logrotate.sh script. The script itself will collect all log files and rotate them, whenever necessary. Arrange for all services in init.d to be able to pick their settings from .env files, if necessary.

Close #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a simple cron-like scheduling system with configurable intervals and logging.
  - Added a dedicated script for automated log rotation of service logs.
  - Added new environment configuration files to support cron scheduling and log rotation.

- **Enhancements**
  - Improved initialization scripts to automatically load configuration defaults from external environment files.
  - Expanded environment variable export for background processes to increase configurability.
  - Updated container setup to include environment files for configuration.
  - Enhanced shell scripts with stricter error handling by adding pipeline failure detection.
  - Standardized script path resolution by switching from `readlink -f` to `realpath` across multiple scripts for improved consistency and reliability.

- **Chores**
  - Ensured the logrotate utility is installed during setup for automated log management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->