### PR TITLE
Silence services by default

### DIFF
--- a/share/tunnels/cloudflare.sh
+++ b/share/tunnels/cloudflare.sh
@@ -45,12 +45,6 @@ sshd_wait() {
     sleep 1
     trace "Waiting for sshd to start on port %s..." "$TUNNEL_SSH"
   done
-  if [ -z "$TUNNEL_REEXPOSE" ] || printf %s\\n "$TUNNEL_REEXPOSE" | grep -qF 'sshd'; then
-    debug "sshd responding on port %s, forwarding logs from %s" "$TUNNEL_SSH" "${TUNNEL_PREFIX}/log/sshd.log"
-    "$CLOUDFLARE_LOGGER" -s "sshd" -- "${TUNNEL_PREFIX}/log/sshd.log" &
-  else
-    debug "sshd responding on port %s" "$TUNNEL_SSH"
-  fi
 }
 
 

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -67,7 +67,7 @@ done
 # List of services which logs we should re-expose to the main container log.
 # When empty, all services will be re-exposed. Set to a dash (-) to disable, for
 # example.
-: "${TUNNEL_REEXPOSE:=""}"
+: "${TUNNEL_REEXPOSE:="-"}"
 
 # Gist where to publish tunnel details
 : "${TUNNEL_GIST:=""}"


### PR DESCRIPTION
By default, all services do not reexpose to the logs. Also make each service responsible for reexposing its log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable environment variables to control log forwarding for Docker and SSH services.
  - Added dedicated logging mechanisms for Docker and SSH, allowing more flexible log management.

- **Chores**
  - Updated the default behavior to disable log re-exposure unless explicitly enabled.
  - Simplified and centralized log forwarding logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->