### PR TITLE
✨ Add session manager

### DIFF
--- a/share/features/60-install-aws.sh
+++ b/share/features/60-install-aws.sh
@@ -32,9 +32,12 @@ if ! command_present "aws"; then
   # Install the AWS CLI. This will bring a large number of python
   # dependencies...
   if is_os_family alpine; then
-    install_packages aws-cli
+    install_packages aws-cli aws-session-manager-plugin
   elif is_os_family debian; then
     install_packages awscli
+    arch=$(get_arch x86_64 64bit)
+    deb="https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_${arch}/session-manager-plugin.deb"
+    internet_deb_installer "$deb" /
   else
     error "Unsupported OS family: %s" "$(get_distro_name)"
   fi


### PR DESCRIPTION
Add the session manager, through official deb package on debian derivatives, and via official package on Alpine

Close #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alpine: Automatically installs AWS CLI and Session Manager Plugin.
  * Debian: Automatically detects system architecture and installs Session Manager Plugin via online package, following AWS CLI installation.
  * Improves out-of-the-box AWS tooling availability across supported environments, reducing manual setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->