### PR TITLE
🐛 Cut long tunnel names

### DIFF
--- a/devenv.sh
+++ b/devenv.sh
@@ -121,7 +121,6 @@ _log() {
   printf "${_fmt}\n" "$@" >&2
 }
 trace() { [ "$DEVENV_VERBOSE" -ge "2" ] && _log DBG "$@" || true ; }
-verbose() { [ "$DEVENV_VERBOSE" -ge "1" ] && _log NFO "$@" || true ; }
 info() { [ "$DEVENV_VERBOSE" -ge "1" ] && _log NFO "$@" || true ; }
 warn() { _log WRN "$@"; }
 error() { _log ERR "$@" && exit 1; }


### PR DESCRIPTION
Cut long tunnel names to max size allowed by code tunnels.
Note: this also reworks a bit logging in the wrapper script to provide for more flexibility

Close #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verbose logging mode with `-v` flag and level-gated log output for better troubleshooting.
  * Implemented automatic tunnel name sizing with truncation and warnings when limits are exceeded.
  * Expanded help and usage text to reflect the new options and invocation name.

* **Improvements**
  * Enhanced shell safety and POSIX compatibility for more robust execution.
  * Broadened option parsing and routed dry-run output through the unified logging framework for clearer, safer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->