### PR TITLE
🔥 Remove building of minimal image in dev

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,22 +37,3 @@ jobs:
       username: ${{ github.actor }}
     secrets:
       password: ${{ secrets.GITHUB_TOKEN }}
-
-  minimal:
-    uses: ./.github/workflows/_build.yml
-    needs: repository
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        os: [alpine, debian]
-    with:
-      image: ${{ github.actor }}/${{ needs.repository.outputs.repository }}-${{ matrix.os }}-minimal
-      platforms: linux/amd64
-      os: ${{ matrix.os }}
-      build-args: |
-        INSTALL_FEATURES=sudo codecli cloudflare git
-      username: ${{ github.actor }}
-    secrets:
-      password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Do not build the minimal image in dev branches. It is a subset of the main image anyway.

Close #75 